### PR TITLE
Use useCallback for increment handler

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Box, Button, Typography } from '@mui/material';
 import { increment } from '../store';
@@ -6,6 +7,7 @@ import { increment } from '../store';
 export default function Home() {
   const count = useSelector((state) => state.counter.value);
   const dispatch = useDispatch();
+  const handleIncrement = useCallback(() => dispatch(increment()), [dispatch]);
 
   return (
     <Box sx={{ p: 4, textAlign: 'center' }}>
@@ -15,7 +17,7 @@ export default function Home() {
       <Typography variant="h6" gutterBottom>
         Count: {count}
       </Typography>
-      <Button variant="contained" onClick={() => dispatch(increment())}>
+      <Button variant="contained" onClick={handleIncrement}>
         Increment
       </Button>
     </Box>


### PR DESCRIPTION
## Summary
- memoize increment dispatch using `useCallback`
- refactor button to use `handleIncrement` callback

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6a45b0cc48326a1cc0255b4efcea6