### PR TITLE
refactor: extract counter slice

### DIFF
--- a/__tests__/counterSlice.test.js
+++ b/__tests__/counterSlice.test.js
@@ -1,0 +1,10 @@
+import { test, expect } from '@jest/globals';
+import counterReducer, { increment } from '../features/counter/counterSlice';
+
+test('should return the initial state', () => {
+  expect(counterReducer(undefined, { type: 'unknown' })).toEqual({ value: 0 });
+});
+
+test('should handle increment', () => {
+  expect(counterReducer({ value: 0 }, increment())).toEqual({ value: 1 });
+});

--- a/features/counter/counterSlice.js
+++ b/features/counter/counterSlice.js
@@ -1,0 +1,15 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const counterSlice = createSlice({
+  name: 'counter',
+  initialState: { value: 0 },
+  reducers: {
+    increment: (state) => {
+      state.value += 1;
+    },
+  },
+});
+
+export const { increment } = counterSlice.actions;
+
+export default counterSlice.reducer;

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Box, Button, Typography } from '@mui/material';
-import { increment } from '../store';
+import { increment } from '../features/counter/counterSlice';
 
 export default function Home() {
   const count = useSelector((state) => state.counter.value);

--- a/store.js
+++ b/store.js
@@ -1,17 +1,10 @@
-import { configureStore, createSlice } from '@reduxjs/toolkit';
+import { configureStore } from '@reduxjs/toolkit';
+import counterReducer, { increment } from './features/counter/counterSlice';
 
-const counterSlice = createSlice({
-  name: 'counter',
-  initialState: { value: 0 },
-  reducers: {
-    increment: (state) => { state.value += 1; }
-  }
-});
-
-export const { increment } = counterSlice.actions;
+export { increment };
 
 const store = configureStore({
-  reducer: { counter: counterSlice.reducer }
+  reducer: { counter: counterReducer }
 });
 
 export default store;


### PR DESCRIPTION
## Summary
- move counter reducer and actions into features/counter/counterSlice.js
- wire store to use new counter slice
- update pages to import increment from slice and add reducer unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6a8ef9ba88326acd27deebce11ed2