### PR TITLE
Use empty basePath for user site deployments

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,18 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
-  basePath: process.env.NODE_ENV === 'production' ? '/janken-plus' : '',
-  assetPrefix: process.env.NODE_ENV === 'production' ? '/janken-plus/' : ''
+  // Use an empty basePath and assetPrefix when deploying to the
+  // user site (janken-plus.github.io). For the project site
+  // repository (janken-plus/janken-plus), keep the /janken-plus
+  // prefix so that assets resolve correctly when published under the
+  // project path. Local development builds (where GITHUB_REPOSITORY is
+  // undefined) will also use the empty prefix.
+  basePath: process.env.GITHUB_REPOSITORY === 'janken-plus/janken-plus'
+    ? '/janken-plus'
+    : '',
+  assetPrefix: process.env.GITHUB_REPOSITORY === 'janken-plus/janken-plus'
+    ? '/janken-plus/'
+    : ''
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- conditionally omit basePath and assetPrefix when deploying the `janken-plus.github.io` user site

## Testing
- `npm test`
- `GITHUB_REPOSITORY=janken-plus/janken-plus.github.io npm run build`
- `grep -R "/janken-plus" -n out`


------
https://chatgpt.com/codex/tasks/task_e_68c6aafb6124832687a07b3f5d3bd662